### PR TITLE
Story dfc 3961 add batchsize for avfeed throttling

### DIFF
--- a/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
+++ b/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
@@ -1,6 +1,8 @@
 {
   "queues":{
-    "batchSize":5,
-    "visibilityTimeout": "00:01:00"
+    "batchSize":4,
+    "visibilityTimeout": "00:01:00",
+    "newBatchThreshold": 4,
+    "maxPollingInterval": 2000
   }
 }

--- a/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
+++ b/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
@@ -1,5 +1,6 @@
 {
   "queues":{
-    "batchSize":5
+    "batchSize":5,
+    "visibilityTimeout": "00:01:00"
   }
 }

--- a/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
+++ b/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/host.json
@@ -1,2 +1,5 @@
 {
+  "queues":{
+    "batchSize":5
+  }
 }


### PR DESCRIPTION
 as long as 4 or fewer instances of the function are running then 4 more message will be dequeued until there are 8 messages being processed with the visibility timeout and polling interval between queue polls.