### PR TITLE
DFC-4700 - Throttling of GetSocMapping function to fix request limit issues

### DIFF
--- a/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/GetSocMappingAzFunction.cs
+++ b/DFC.Integration.AVFeed/DFC.Integration.AVFeed.AzureFunctions/GetSocMappingAzFunction.cs
@@ -39,7 +39,7 @@ namespace DFC.Integration.AVFeed.AzureFunctions
                 await output.AddAsync(item);
                 await output.FlushAsync();
                 await Task.Delay(Constants.AVFeedSecondsBetweenGetForSOC * 1000);
-                log.Info($"C# Timer trigger function executing at: {DateTime.Now} with CorrelationId:{correlationId} - Added SOC mapping to the queue total so far added {counter++} of {total} added to the queue and waiting for a minute");
+                log.Info($"C# Timer trigger function executing at: {DateTime.Now} with CorrelationId:{correlationId} - Added SOC mapping to the queue total so far added {counter++} of {total} to the queue and waiting for {Constants.AVFeedSecondsBetweenGetForSOC} seconds");
             }
 
             await auditRecord.AddAsync(new AuditRecord<string, IEnumerable<SocMapping>>

--- a/DFC.Integration.AVFeed/DFC.Integration.AVFeed.Core/Constants.cs
+++ b/DFC.Integration.AVFeed/DFC.Integration.AVFeed.Core/Constants.cs
@@ -8,5 +8,7 @@
         public static string ApprenticeshipEndpoint => ConfigurationManager.AppSettings.Get("FAA.Endpoint");
         public static string ApprenticeshipEndpointKey=> ConfigurationManager.AppSettings.Get("FAA.PublicKey");
         public static string ExternalApplicationId => ConfigurationManager.AppSettings.Get("FAA.ExternalSystemId");
+        public static int AVFeedSecondsBetweenGetForSOC => int.Parse(ConfigurationManager.AppSettings.Get("AVFeedSecondsBetweenGetForSOC"));
+
     }
 }

--- a/DFC.Integration.AVFeed/DFC.Integration.Azure.Resources/Function App/parameters.json
+++ b/DFC.Integration.AVFeed/DFC.Integration.Azure.Resources/Function App/parameters.json
@@ -73,6 +73,9 @@
     },
     "FAA.SortBy": {
       "value": "Age"
+    },
+    "AVFeedSecondsBetweenGetForSOC": {
+      "value": "2"
     }
   }
 }

--- a/DFC.Integration.AVFeed/DFC.Integration.Azure.Resources/Function App/template.json
+++ b/DFC.Integration.AVFeed/DFC.Integration.Azure.Resources/Function App/template.json
@@ -71,6 +71,9 @@
     },
     "FAA.SortBy": {
       "type": "string"
+    },
+    "AVFeedSecondsBetweenGetForSOC": {
+      "type": "string"
     }
   },
   "resources": [


### PR DESCRIPTION
Changed the way that we throttle the AV feed. So that we do not exceed request limits and get retry warning in insights.